### PR TITLE
Add auto-clean functionality

### DIFF
--- a/build
+++ b/build
@@ -23,7 +23,7 @@ if [ -z "$WHARFRAT_NAME" ]; then
         wr="$(pwd)/dist/bootstrap/wr";
     fi
 
-    exec "$wr" --clean "./$(basename "$0")" "$@";
+    exec "$wr" --auto-clean "./$(basename "$0")" "$@";
 fi
 
 ver=$(

--- a/build
+++ b/build
@@ -19,7 +19,7 @@ if [ -z "$WHARFRAT_NAME" ]; then
         echo "bootstrap ...";
         mkdir -p dist/bootstrap
         image="$(egrep -o 'wharfr/dev(:[^"]*)?' .wrproject)"
-        docker run -it --rm -v $(pwd):/go/src/wharfr.at/wharfrat "${image}" go build -o /go/src/wharfr.at/wharfrat/dist/bootstrap/wr wharfr.at/wharfrat/cmd/wr
+        docker run -i --rm -v $(pwd):/go/src/wharfr.at/wharfrat "${image}" go build -o /go/src/wharfr.at/wharfrat/dist/bootstrap/wr wharfr.at/wharfrat/cmd/wr
         wr="$(pwd)/dist/bootstrap/wr";
     fi
 

--- a/build
+++ b/build
@@ -14,7 +14,7 @@ if [ -z "$WHARFRAT_NAME" ]; then
         wr="$(pwd)/dist/wr";
     fi
 
-    if ! "$wr" --force true 2> /dev/null; then
+    if ! "$wr" --auto-clean --force true 2> /dev/null; then
         # We need to bootstrap the build by using docker directly
         echo "bootstrap ...";
         mkdir -p dist/bootstrap

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -114,6 +114,7 @@ If ``$XDG_CONFIG_HOME`` is not set, then the default path is
 .. code-block:: toml
 
   docker-url = "file:///var/run/docker.sock"
+  auto-clean = true
 
   [[setups]]
       project = ".*/test"
@@ -159,6 +160,9 @@ The available settings are:
 
 +------------+-----------------------------------------------------------------+
 | docker-url | The URL to use to connect to Docker                             |
++------------+-----------------------------------------------------------------+
+| auto-clean | If set to true, then wharfrat run will automatically replace    |
+|            | containers that were built from old config, or the wrong image. |
 +------------+------------+----------------------------------------------------+
 | setups     | project    | a regular expression that much match the project   |
 |            |            | path for this setup to be applies. If not          |

--- a/lib/cmd/wharfrat/run.go
+++ b/lib/cmd/wharfrat/run.go
@@ -11,12 +11,13 @@ import (
 )
 
 type Run struct {
-	Stop    bool   `short:"s" long:"stop" description:"Stop contiainer instead of running command"`
-	Crate   string `short:"c" long:"crate" value-name:"NAME" description:"Name of crate to run"`
-	Clean   bool   `long:"clean" description:"Rebuild container from Image"`
-	User    string `short:"u" long:"user" value-name:"USER[:GROUP]" description:"Override user/group for running command"`
-	Workdir string `short:"w" long:"workdir" value-name:"DIR" description:"Override working directory for running command"`
-	Force   bool   `long:"force" description:"Ignore out of date crate configuration"`
+	Stop      bool   `short:"s" long:"stop" description:"Stop contiainer instead of running command"`
+	Crate     string `short:"c" long:"crate" value-name:"NAME" description:"Name of crate to run"`
+	Clean     bool   `long:"clean" description:"Rebuild container from Image"`
+	AutoClean bool   `long:"auto-clean" description:"Automatically apply --clean, if the container is old"`
+	User      string `short:"u" long:"user" value-name:"USER[:GROUP]" description:"Override user/group for running command"`
+	Workdir   string `short:"w" long:"workdir" value-name:"DIR" description:"Override working directory for running command"`
+	Force     bool   `long:"force" description:"Ignore out of date crate configuration"`
 }
 
 func (opts *Run) stop(args []string) error {
@@ -72,7 +73,7 @@ func (opts *Run) client(args []string) (int, error) {
 		}
 	}
 
-	container, err := c.EnsureRunning(crate, opts.Force)
+	container, err := c.EnsureRunning(crate, opts.Force, opts.AutoClean)
 	if err != nil {
 		return 1, fmt.Errorf("Failed to run container: %s", err)
 	}

--- a/lib/cmd/wharfrat/run.go
+++ b/lib/cmd/wharfrat/run.go
@@ -11,13 +11,14 @@ import (
 )
 
 type Run struct {
-	Stop      bool   `short:"s" long:"stop" description:"Stop contiainer instead of running command"`
-	Crate     string `short:"c" long:"crate" value-name:"NAME" description:"Name of crate to run"`
-	Clean     bool   `long:"clean" description:"Rebuild container from Image"`
-	AutoClean bool   `long:"auto-clean" description:"Automatically apply --clean, if the container is old"`
-	User      string `short:"u" long:"user" value-name:"USER[:GROUP]" description:"Override user/group for running command"`
-	Workdir   string `short:"w" long:"workdir" value-name:"DIR" description:"Override working directory for running command"`
-	Force     bool   `long:"force" description:"Ignore out of date crate configuration"`
+	Stop        bool   `short:"s" long:"stop" description:"Stop contiainer instead of running command"`
+	Crate       string `short:"c" long:"crate" value-name:"NAME" description:"Name of crate to run"`
+	Clean       bool   `long:"clean" description:"Rebuild container from Image"`
+	AutoClean   bool   `long:"auto-clean" description:"Automatically apply --clean, if the container is old"`
+	NoAutoClean bool   `long:"no-auto-clean" description:"Disable auto-clean, if enabled in local config"`
+	User        string `short:"u" long:"user" value-name:"USER[:GROUP]" description:"Override user/group for running command"`
+	Workdir     string `short:"w" long:"workdir" value-name:"DIR" description:"Override working directory for running command"`
+	Force       bool   `long:"force" description:"Ignore out of date crate configuration"`
 }
 
 func (opts *Run) stop(args []string) error {
@@ -43,6 +44,10 @@ func (opts *Run) stop(args []string) error {
 }
 
 func (opts *Run) client(args []string) (int, error) {
+	if opts.AutoClean && opts.NoAutoClean {
+		return 1, fmt.Errorf("--auto-clean and --no-auto-clean are not compatible")
+	}
+
 	c, err := docker.Connect()
 	if err != nil {
 		return 1, fmt.Errorf("Failed to create docker client: %s", err)
@@ -73,7 +78,15 @@ func (opts *Run) client(args []string) (int, error) {
 		}
 	}
 
-	container, err := c.EnsureRunning(crate, opts.Force, opts.AutoClean)
+	autoClean := config.Local().AutoClean
+	switch {
+	case opts.AutoClean:
+		autoClean = true
+	case opts.NoAutoClean:
+		autoClean = false
+	}
+
+	container, err := c.EnsureRunning(crate, opts.Force, autoClean)
 	if err != nil {
 		return 1, fmt.Errorf("Failed to run container: %s", err)
 	}

--- a/lib/cmd/wharfrat/start.go
+++ b/lib/cmd/wharfrat/start.go
@@ -66,7 +66,7 @@ func (s *Start) Execute(args []string) error {
 				fmt.Printf("Failed to start %s: crate config mising\n", name)
 				continue
 			}
-			if _, err := client.EnsureRunning(crate, s.Force); err != nil {
+			if _, err := client.EnsureRunning(crate, s.Force, false); err != nil {
 				fmt.Printf("Failed to start %s: %s\n", name, err)
 			} else {
 				fmt.Printf("%s started\n", name)

--- a/lib/config/local.go
+++ b/lib/config/local.go
@@ -23,6 +23,7 @@ type LocalSetup struct {
 
 type LocalConfig struct {
 	DockerURL string       `toml:"docker-url"`
+	AutoClean bool         `toml:"auto-clean"`
 	Setups    []LocalSetup `toml:"setups"`
 	path      string
 }

--- a/lib/docker/ensure.go
+++ b/lib/docker/ensure.go
@@ -29,6 +29,7 @@ func (c *Connection) EnsureRunning(crate *config.Crate, force, removeOld bool) (
 			if err := c.Remove(crate.ContainerName(), true); err != nil {
 				return "", err
 			}
+			return c.Create(crate)
 		} else {
 			return "", fmt.Errorf("Container built from old config")
 		}
@@ -48,6 +49,7 @@ func (c *Connection) EnsureRunning(crate *config.Crate, force, removeOld bool) (
 			if err := c.Remove(crate.ContainerName(), true); err != nil {
 				return "", err
 			}
+			return c.Create(crate)
 		} else {
 			return "", fmt.Errorf("Container built from wrong (old?) image")
 		}

--- a/lib/docker/ensure.go
+++ b/lib/docker/ensure.go
@@ -8,7 +8,7 @@ import (
 	"wharfr.at/wharfrat/lib/docker/label"
 )
 
-func (c *Connection) EnsureRunning(crate *config.Crate, force bool) (string, error) {
+func (c *Connection) EnsureRunning(crate *config.Crate, force, removeOld bool) (string, error) {
 	container, err := c.GetContainer(crate.ContainerName())
 	if err != nil {
 		return "", fmt.Errorf("Failed to get docker container: %s", err)
@@ -21,8 +21,17 @@ func (c *Connection) EnsureRunning(crate *config.Crate, force bool) (string, err
 	log.Printf("FOUND %s %s", container.ID, container.State)
 
 	oldJson := container.Config.Labels[label.Config]
-	if oldJson != crate.Json() && !force {
-		return "", fmt.Errorf("Container built from old config")
+	if oldJson != crate.Json() {
+		if force {
+			log.Printf("Forcing use of container built from old config")
+		} else if removeOld {
+			log.Printf("Automatically removing container built from old config")
+			if err := c.Remove(crate.ContainerName(), true); err != nil {
+				return "", err
+			}
+		} else {
+			return "", fmt.Errorf("Container built from old config")
+		}
 	}
 
 	image, err := c.GetImage(crate.Image)
@@ -30,9 +39,18 @@ func (c *Connection) EnsureRunning(crate *config.Crate, force bool) (string, err
 		return "", err
 	}
 
-	if container.Image != image.ID && !force {
+	if container.Image != image.ID {
 		log.Printf("CONTAINER IMAGE: wanted \"%s\", got \"%s\"", image.ID, container.Image)
-		return "", fmt.Errorf("Container built from wrong (old?) image")
+		if force {
+			log.Printf("Forcing use of container built from old image")
+		} else if removeOld {
+			log.Printf("Automatically removing container built from old image")
+			if err := c.Remove(crate.ContainerName(), true); err != nil {
+				return "", err
+			}
+		} else {
+			return "", fmt.Errorf("Container built from wrong (old?) image")
+		}
 	}
 
 	switch container.State.Status {

--- a/lib/exec/exec.go
+++ b/lib/exec/exec.go
@@ -61,7 +61,7 @@ func (e *ExecCfg) Execute(args []string) (int, error) {
 		return 0, err
 	}
 	log.Printf("CRATE: %#v", crate)
-	container, err := client.EnsureRunning(crate, false)
+	container, err := client.EnsureRunning(crate, false, false)
 	if err != nil {
 		return 1, fmt.Errorf("Failed to run container: %s", err)
 	}


### PR DESCRIPTION
Add a command line option, and local config setting to enable automatic cleaning of old containers. If you call run with the --auto-clean option, or set the auto-clean local config setting to true, then any container that was built from old configuration or an old image will be removed and replaced with a new one.

This has the same functional effect as always running with --clean, except it doesn't remove the container if the config hasn't changed.