### PR TITLE
Update to using Go 1.11.2

### DIFF
--- a/.wrproject
+++ b/.wrproject
@@ -1,11 +1,12 @@
 default = "dev"
 
 [crates.dev]
-  image = "wharfr/dev:1.11.0"
+  image = "wharfr/dev:1.11.2"
   mount-home = false
   project-mount = "/go/src/wharfr.at/wharfrat"
   working-dir = "project, match"
   env-blacklist = ["GOPATH"]
+  shell = "/bin/sh"
 
 [crates.docs]
   image = "wharfr/docs"

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -27,7 +27,7 @@ if [ -z "$WHARFRAT_NAME" ]; then
 fi
 
 ver=$(
-cat << EOF | base64 -w 0
+cat << EOF | base64 | tr -d '\n'
 {"version":"$(git describe --dirty --match "v[0-9]*")","commit":"$(git rev-parse HEAD)","buildtime":"$(date --utc +%Y-%m-%dT%H:%M:%SZ)"}
 EOF
 )

--- a/images/dev/Dockerfile
+++ b/images/dev/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.11
+FROM golang:1.11.2-alpine
+
+RUN apk add --no-cache git
 
 # We have to unvendor go-connections, as it is used by the docker client API -
 # so we need the docker client to agree with us about which library we are


### PR DESCRIPTION
Also switch to the alpine version of the base golang image, as it's smaller -
though that does require a couple of small tweaks to the build script.

Signed-off-by: Julian Phillips <julian@quantumfyre.co.uk>