### PR TITLE
Include commit hash when checking for staleness

### DIFF
--- a/lib/docker/create.go
+++ b/lib/docker/create.go
@@ -14,6 +14,7 @@ import (
 
 	"wharfr.at/wharfrat/lib/config"
 	"wharfr.at/wharfrat/lib/docker/label"
+	"wharfr.at/wharfrat/lib/version"
 	"wharfr.at/wharfrat/lib/vc"
 
 	"github.com/docker/distribution/reference"
@@ -123,6 +124,7 @@ func (c *Connection) Create(crate *config.Crate) (string, error) {
 	labels := map[string]string{
 		label.Project: crate.ProjectPath(),
 		label.Crate:   crate.Name(),
+		label.Commit:  version.Commit(),
 		label.Config:  crate.Json(),
 		label.User:    usr.Username,
 	}

--- a/lib/docker/docker.go
+++ b/lib/docker/docker.go
@@ -12,7 +12,6 @@ import (
 	"wharfr.at/wharfrat/lib/config"
 	"wharfr.at/wharfrat/lib/docker/label"
 
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
@@ -22,10 +21,6 @@ import (
 type Connection struct {
 	c   *client.Client
 	ctx context.Context
-}
-
-func Version() string {
-	return api.DefaultVersion
 }
 
 func Connect() (*Connection, error) {

--- a/lib/docker/ensure.go
+++ b/lib/docker/ensure.go
@@ -6,6 +6,7 @@ import (
 
 	"wharfr.at/wharfrat/lib/config"
 	"wharfr.at/wharfrat/lib/docker/label"
+	"wharfr.at/wharfrat/lib/version"
 )
 
 func (c *Connection) EnsureRunning(crate *config.Crate, force, removeOld bool) (string, error) {
@@ -20,8 +21,9 @@ func (c *Connection) EnsureRunning(crate *config.Crate, force, removeOld bool) (
 
 	log.Printf("FOUND %s %s", container.ID, container.State)
 
+	oldCommit := container.Config.Labels[label.Commit]
 	oldJson := container.Config.Labels[label.Config]
-	if oldJson != crate.Json() {
+	if oldJson != crate.Json() || oldCommit != version.Commit() {
 		if force {
 			log.Printf("Forcing use of container built from old config")
 		} else if removeOld {

--- a/lib/docker/label/label.go
+++ b/lib/docker/label/label.go
@@ -6,6 +6,7 @@ const domain = "at.wharfr.wharfrat"
 const (
 	Project = domain + ".project"
 	Crate   = domain + ".crate"
+	Commit  = domain + ".commit"
 	Config  = domain + ".config"
 	Branch  = domain + ".branch"
 	User    = domain + ".user"

--- a/lib/version/version.go
+++ b/lib/version/version.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"time"
 
-	"wharfr.at/wharfrat/lib/docker"
+	"github.com/docker/docker/api"
 )
 
 var versionString = "eyJ2ZXJzaW9uIjoidjAuOS4wLWRldiIsImNvbW1pdCI6ImYzNThkZmUyMGZjOGIwZTJlMDBhY2VlMjczYzY5Y2I0M2JiZTFiNzUiLCJidWlsZHRpbWUiOiIyMDE5LTA5LTI5VDE4OjEyOjQ0WiJ9Cg=="
@@ -23,7 +23,7 @@ var version versionInfo
 func ShowVersion() error {
 	fmt.Printf("Version: %s\n", version.Version)
 	fmt.Printf("Git Commit: %s\n", version.Commit)
-	fmt.Printf("Docker API Version: %s\n", docker.Version())
+	fmt.Printf("Docker API Version: %s\n", api.DefaultVersion)
 	fmt.Printf("Go Version: %s\n", runtime.Version())
 	fmt.Printf("Built: %s\n", version.BuildTime.Local())
 	return nil


### PR DESCRIPTION
Since we include a copy of the wharfrat tool (as wr-init) in the
container that we run, then the container should be considered stale if
built with a different version of wharfrat.