### PR TITLE
Network setting

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -37,6 +37,8 @@ default values (if the default is not empty):
 | mount-home    | bool             | should /home be mounted into container    |
 |               |                  | (default: true)                           |
 +---------------+------------------+-------------------------------------------+
+| network       | string           | the network to connect the container to   |
++---------------+------------------+-------------------------------------------+
 | ports         | array of strings | ports to be exposed from container (-p    |
 |               |                  | option to docker)                         |
 +---------------+------------------+-------------------------------------------+

--- a/lib/config/crate.go
+++ b/lib/config/crate.go
@@ -33,6 +33,7 @@ type Crate struct {
 	Hostname     string            `toml:"hostname"`
 	Image        string            `toml:"image"`
 	MountHome    bool              `toml:"mount-home"`
+	Network      string            `toml:"network"`
 	Ports        []string          `toml:"ports"`
 	ProjectMount string            `toml:"project-mount"`
 	SetupPost    string            `toml:"setup-post"`

--- a/lib/docker/create.go
+++ b/lib/docker/create.go
@@ -192,6 +192,7 @@ func (c *Connection) Create(crate *config.Crate) (string, error) {
 		DNS:          []string{},
 		DNSSearch:    []string{},
 		DNSOptions:   []string{},
+		NetworkMode:  container.NetworkMode(crate.Network),
 	}
 
 	networkingConfig := &network.NetworkingConfig{}


### PR DESCRIPTION
Add a new "network" setting to the crate setting. This is the equivalent of the "--network" option to "docker run".