### PR TITLE
Scriptable crate Image

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,6 +34,9 @@ default values (if the default is not empty):
 +---------------+------------------+-------------------------------------------+
 | image         | string           | name of image to create container from    |
 +---------------+------------------+-------------------------------------------+
+| image-cmd     | string           | a script to run to determine the image    |
+|               |                  | name (instead of using image).            |
++---------------+------------------+-------------------------------------------+
 | mount-home    | bool             | should /home be mounted into container    |
 |               |                  | (default: true)                           |
 +---------------+------------------+-------------------------------------------+

--- a/lib/config/crate.go
+++ b/lib/config/crate.go
@@ -112,10 +112,11 @@ func runImageCmd(command string, projectDir string) (string, error) {
 	cmd := exec.Command(shell[0], shell[1:]...)
 	cmd.Stdin = strings.NewReader(command)
 	cmd.Stdout = buf
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return "", err
 	}
-	return buf.String(), nil
+	return strings.TrimSpace(buf.String()), nil
 }
 
 func openCrate(project *Project, crateName, branch string, ls LabelSource) (*Crate, error) {
@@ -127,7 +128,7 @@ func openCrate(project *Project, crateName, branch string, ls LabelSource) (*Cra
 	if crate.ImageCmd != "" {
 		image, err := runImageCmd(crate.ImageCmd, filepath.Dir(project.path))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("image-cmd failed: %s", err)
 		}
 		if image != "" {
 			crate.Image = image


### PR DESCRIPTION
Add a crate setting that allows using a script to determine the image name, instead of it having to be a fixed string.