### PR TITLE
Ensure containers are running when creating environments

### DIFF
--- a/lib/cmd/wharfrat/list.go
+++ b/lib/cmd/wharfrat/list.go
@@ -11,6 +11,7 @@ import (
 	"wharfr.at/wharfrat/lib/docker"
 	"wharfr.at/wharfrat/lib/docker/label"
 	"wharfr.at/wharfrat/lib/vc"
+	"wharfr.at/wharfrat/lib/version"
 )
 
 type List struct {
@@ -131,6 +132,7 @@ func (l *List) Execute(args []string) error {
 		crateName := container.Labels[label.Crate]
 		cfg := container.Labels[label.Config]
 		branch := container.Labels[label.Branch]
+		commit := container.Labels[label.Commit]
 
 		name := container.Names[0]
 		if strings.HasPrefix(name, "/") {
@@ -179,7 +181,7 @@ func (l *List) Execute(args []string) error {
 		crateState := green
 		if crate == nil {
 			crateState = red
-		} else if crate.Json() != cfg {
+		} else if crate.Json() != cfg || version.Commit() != commit {
 			crateState = amber
 		}
 

--- a/lib/venv/state.go
+++ b/lib/venv/state.go
@@ -64,14 +64,12 @@ func newState(path, project string, crates []string, c *docker.Connection) (*sta
 			return nil, fmt.Errorf("Config error: %s", err)
 		}
 		log.Printf("Crate: %#v", crate)
-		container, err := c.GetContainer(crate.ContainerName())
+		id, err := c.EnsureRunning(crate, false, true)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get docker container: %s", err)
+			return nil, fmt.Errorf("Failed to get running container: %s", err)
 		}
-		if container != nil {
-			if err := s.Update(c, container.ID, crate, "", "", nil); err != nil {
-				return nil, fmt.Errorf("failed to update exported binaries: %s", err)
-			}
+		if err := s.Update(c, id, crate, "", "", nil); err != nil {
+			return nil, fmt.Errorf("failed to update exported binaries: %s", err)
 		}
 	}
 	return s, nil


### PR DESCRIPTION
We need to ensure that the container is running in order to correctly update the exported binaries correctly.