### PR TITLE
Fix issue with packaging script

### DIFF
--- a/package/build
+++ b/package/build
@@ -25,13 +25,13 @@ echo -e "${c}insert version into spec file ...${r}"
 sed -e "s#@@VERSION@@#$version#" -e "s#@@RELEASE@@#$release#" wharfrat.spec > tmp.spec
 
 echo -e "${c}build rpm ...${r}"
-../dist/wr -c rpm rpmbuild --define "_topdir /wharfrat/package/rpm-root" -bb tmp.spec
+../dist/wr --auto-clean -c rpm rpmbuild --define "_topdir /wharfrat/package/rpm-root" -bb tmp.spec
 if ! [ -L "rpms" ]; then
     ln -sf rpm-root/RPMS/x86_64 rpms
 fi
 
 echo -e "${c}build deb ...${r}"
-../dist/wr -c deb bash ./build-deb "$version" "$release"
+../dist/wr --auto-clean -c deb bash ./build-deb "$version" "$release"
 
 echo -e "${c}cleanup ...${r}"
 rm tmp.spec


### PR DESCRIPTION
The packaging script was failing due to stale crates, so add
--auto-clean to the wr calls.