### PR TITLE
Allow variable expansion in volume mounts

### DIFF
--- a/lib/config/crate.go
+++ b/lib/config/crate.go
@@ -284,3 +284,18 @@ func (c *Crate) Hash() string {
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }
+
+func (c *Crate) Getenvish(name string) string {
+	switch name {
+	case "WHARFRAT_NAME":
+		return c.ContainerName()
+	case "WHARFRAT_CRATE":
+		return c.Name()
+	case "WHARFRAT_PROJECT":
+		return c.ProjectPath()
+	case "WHARFRAT_PROJECT_DIR":
+		return filepath.Dir(c.ProjectPath())
+	default:
+		return os.Getenv(name)
+	}
+}

--- a/lib/docker/create.go
+++ b/lib/docker/create.go
@@ -176,7 +176,9 @@ func (c *Connection) Create(crate *config.Crate) (string, error) {
 	}
 
 	if crate.Volumes != nil {
-		binds = append(binds, crate.Volumes...)
+		for _, volume := range crate.Volumes {
+			binds = append(binds, os.Expand(volume, crate.Getenvish))
+		}
 	}
 
 	log.Printf("BINDS: %v", binds)

--- a/lib/docker/exec.go
+++ b/lib/docker/exec.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -30,12 +31,13 @@ func buildEnv(id string, crate *config.Crate) ([]string, error) {
 		"WHARFRAT_NAME=" + crate.ContainerName(),
 		"WHARFRAT_CRATE=" + crate.Name(),
 		"WHARFRAT_PROJECT=" + crate.ProjectPath(),
+		"WHARFRAT_PROJECT_DIR=" + filepath.Dir(crate.ProjectPath()),
 	}
 
 	log.Printf("CRATE ENV: %v", crate.Env)
 	for name, value := range crate.Env {
 		switch name {
-		case "WHARFRAT_ID", "WHARFRAT_NAME", "WHARFRAT_CRATE", "WHARFRAT_PROJECT":
+		case "WHARFRAT_ID", "WHARFRAT_NAME", "WHARFRAT_CRATE", "WHARFRAT_PROJECT", "WHARFRAT_PROJECT_DIR":
 			log.Printf("Ignoring attempt to change %s", name)
 		default:
 			env = append(env, name+"="+value)
@@ -51,7 +53,7 @@ func buildEnv(id string, crate *config.Crate) ([]string, error) {
 		log.Printf("LOCAL ENV: %v", local.Env)
 		for name, value := range local.Env {
 			switch name {
-			case "WHARFRAT_ID", "WHARFRAT_NAME", "WHARFRAT_CRATE", "WHARFRAT_PROJECT":
+			case "WHARFRAT_ID", "WHARFRAT_NAME", "WHARFRAT_CRATE", "WHARFRAT_PROJECT", "WHARFRAT_PROJECT_DIR":
 				log.Printf("Ignoring attempt to change %s", name)
 			default:
 				env = append(env, name+"="+value)


### PR DESCRIPTION
You can now use environment variables when specifying volume mounts. We
also include the WHARFRAT_ crate variables - though they are not real
environment variables. In particular, this allows the use of
"${WHARFRAT_PROJECT_DIR}" in a volume mount to specify paths relative to
the wharfrat project file's directory (since docker does not allow
relative paths when mounting volumes).

Signed-off-by: Julian Phillips <julian@quantumfyre.co.uk>