### PR TITLE
Add a env prune command to remove old scripts

### DIFF
--- a/lib/cmd/wharfrat/env.go
+++ b/lib/cmd/wharfrat/env.go
@@ -12,6 +12,7 @@ type Env struct {
 	EnvCreate `command:"create" description:"Create a new environment"`
 	EnvUpdate `command:"update" description:"Update the local wharfrat in the environment"`
 	EnvInfo   `command:"info" description:"Display information about the current environment"`
+	EnvPrune  `command:"prune" description:"Remove any obsolete parts of the environment"`
 }
 
 func (e *Env) Usage() string {
@@ -59,4 +60,12 @@ func (ei *EnvInfo) Execute(args []string) error {
 	venv.DisplayInfo()
 
 	return nil
+}
+
+type EnvPrune struct {
+	Remove bool `short:"r" long:"remove" description:"Remove any obsolete items found"`
+}
+
+func (ep *EnvPrune) Execute(args []string) error {
+	return venv.Prune(ep.Remove)
 }

--- a/lib/exec/exec.go
+++ b/lib/exec/exec.go
@@ -5,44 +5,25 @@ import (
 	"log"
 	"path/filepath"
 
-	"github.com/BurntSushi/toml"
 	"wharfr.at/wharfrat/lib/config"
 	"wharfr.at/wharfrat/lib/docker"
+	"wharfr.at/wharfrat/lib/exec/script"
 	"wharfr.at/wharfrat/lib/venv"
 )
 
-type ExecCfg struct {
-	Args      []string `toml:"args"`
-	Command   []string `toml:"command"`
-	Crate     string   `toml:"crate"`
-	Project   string   `toml:"project"`
-	User      string   `toml:"user"`
-	AutoClean bool     `toml:"auto-clean"`
-	path      string
-	meta      toml.MetaData
-}
+type ExecCfg script.Script
 
 func Parse(path string) (*ExecCfg, error) {
-	absPath, err := filepath.Abs(path)
+	s, err := script.Parse(path)
 	if err != nil {
 		return nil, err
 	}
-	var cfg ExecCfg
-	md, err := toml.DecodeFile(absPath, &cfg)
-	if err != nil {
-		return nil, err
-	}
-	log.Printf("Unknown config keys: %s", md.Undecoded())
-	log.Printf("ExecCfg File: %s", absPath)
-	log.Printf("ExecCfg: %#v", cfg)
-	cfg.path = absPath
-	cfg.meta = md
-	return &cfg, nil
+	return (*ExecCfg)(s), nil
 }
 
 func (e *ExecCfg) getCrate(ls config.LabelSource) (*config.Crate, error) {
 	path := e.Project
-	base := filepath.Dir(e.path)
+	base := filepath.Dir(e.Path)
 	if path == "" {
 		return config.GetCrate(base, e.Crate, ls)
 	}
@@ -69,10 +50,10 @@ func (e *ExecCfg) Execute(args []string) (int, error) {
 	}
 	cmd := e.Command
 	if len(cmd) == 0 {
-		name := filepath.Base(e.path)
+		name := filepath.Base(e.Path)
 		cmd = []string{name}
 	}
-	if e.meta.IsDefined("args") {
+	if e.Meta.IsDefined("args") {
 		args = e.Args
 	}
 	cmd = append(cmd, args...)

--- a/lib/exec/script/script.go
+++ b/lib/exec/script/script.go
@@ -1,0 +1,37 @@
+package script
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+type Script struct {
+	Args      []string `toml:"args"`
+	Command   []string `toml:"command"`
+	Crate     string   `toml:"crate"`
+	Project   string   `toml:"project"`
+	User      string   `toml:"user"`
+	AutoClean bool     `toml:"auto-clean"`
+	Path      string
+	Meta      toml.MetaData
+}
+
+func Parse(path string) (*Script, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Script
+	md, err := toml.DecodeFile(absPath, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Unknown config keys: %s", md.Undecoded())
+	log.Printf("ExecCfg File: %s", absPath)
+	log.Printf("ExecCfg: %#v", cfg)
+	cfg.Path = absPath
+	cfg.Meta = md
+	return &cfg, nil
+}

--- a/lib/venv/prune.go
+++ b/lib/venv/prune.go
@@ -1,0 +1,145 @@
+package venv
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"wharfr.at/wharfrat/lib/config"
+	"wharfr.at/wharfrat/lib/docker"
+	"wharfr.at/wharfrat/lib/exec/script"
+)
+
+func Prune(remove bool) error {
+	state, err := loadState()
+	if err != nil {
+		return fmt.Errorf("failed to load state: %s", err)
+	}
+	if state == nil {
+		return fmt.Errorf("environment not activated")
+	}
+
+	client, err := docker.Connect()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	cfgs, err := findExecScripts(state)
+	if err != nil {
+		return err
+	}
+
+	for crate, scripts := range cfgs {
+		if err := pruneCrate(client, state, crate, scripts, remove); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func findExecScripts(state *state) (map[string]map[string]string, error) {
+	binDir := filepath.Join(state.EnvPath, "bin")
+	entries, err := os.ReadDir(binDir)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() {
+			continue
+		}
+		paths = append(paths, filepath.Join(binDir, entry.Name()))
+	}
+	log.Printf("ENTRIES: %s", paths)
+	scripts := map[string]map[string]string{}
+	for _, path := range paths {
+		if b, err := isExecScript(path); err != nil {
+			return nil, err
+		} else if !b {
+			log.Printf("Ignore non-script: %s", path)
+			continue
+		}
+		c, err := script.Parse(path)
+		if err != nil {
+			return nil, err
+		}
+		if scripts[c.Crate] == nil {
+			scripts[c.Crate] = make(map[string]string)
+		}
+		scripts[c.Crate][path] = c.Command[0]
+	}
+	log.Printf("SCRIPTS: %s", scripts)
+	return scripts, nil
+}
+
+func isExecScript(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	firstLine, err := bufio.NewReader(f).ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	log.Printf("Check first line (%s): %s", path, firstLine)
+	if strings.HasPrefix(firstLine, "#!") && strings.HasSuffix(firstLine, "/wr-exec\n") {
+		return true, nil
+	}
+	return false, nil
+}
+
+func pruneCrate(c *docker.Connection, state *state, crateName string, scripts map[string]string, remove bool) error {
+	crate, err := config.OpenCrate(state.Project, crateName, c)
+	if err != nil {
+		return err
+	}
+	container, err := c.EnsureRunning(crate, false, false)
+	if err != nil {
+		return fmt.Errorf("failed to run container: %w", err)
+	}
+	paths, err := getBinaries(c, container, crate, "", crate.ExportBin)
+	if err != nil {
+		return err
+	}
+	log.Printf("PATHS: %s", paths)
+	targets := map[string]bool{}
+	for _, target := range paths {
+		targets[target] = true
+	}
+	missing := []string{}
+	for script, target := range scripts {
+		if targets[target] {
+			continue
+		}
+		log.Printf("MISSING: %s", script)
+		missing = append(missing, script)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	fmt.Printf("Scripts with missing commands:\n")
+	for _, script := range missing {
+		fmt.Printf("  %s\n", script)
+	}
+
+	if !remove {
+		fmt.Printf("\nre-run with -r/--remove to remove\n")
+		return nil
+	}
+
+	for _, script := range missing {
+		if err := os.Remove(script); err != nil {
+			log.Printf("ERROR: Failed to remove %s: %s", script, err)
+			fmt.Printf("Failed to remove %s", script)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
If there are old scripts in the env that no longer point at existing commands
in the container, then running "env prune -r" will now remove them (or running
just "env prune" will list them).